### PR TITLE
Remove constraint in skill table

### DIFF
--- a/src/main/java/dev/fmagallanes97/backendportfolio/model/Skill.java
+++ b/src/main/java/dev/fmagallanes97/backendportfolio/model/Skill.java
@@ -15,7 +15,7 @@ public class Skill {
     private Long id;
     private String name;
     @ManyToOne
-    @JoinColumn(name = "skill_type_id")
+    @JoinColumn(name = "type_id")
     private SkillType type;
     @ManyToOne
     @JoinColumn(name = "resume_id")

--- a/src/main/resources/db/migration/V1.4__remove_constraint_skill_table.sql
+++ b/src/main/resources/db/migration/V1.4__remove_constraint_skill_table.sql
@@ -1,0 +1,2 @@
+alter table skill
+    change skill_type_id type_id bigint null;


### PR DESCRIPTION
## Changes Made

- Created migration to remove one constraint in the skill table
- Updated the column name mapper in the skill entity

## Reason for Changes

The constraint was deleted because having the value in the first instance was unnecessary.  This affected the endpoint too since it was mandatory to pass the resume id and the skill type id at the same time.

